### PR TITLE
Docfix: change order of examples to make comments accurate

### DIFF
--- a/lib/Devel/Trepan.pm
+++ b/lib/Devel/Trepan.pm
@@ -199,9 +199,9 @@ However when this command is aliased from a command ending in !, no
 questions are asked.
 
     kill  
+    kill TERM # Send "TERM" signal
     kill unconditionally
     kill KILL # same as above
-    kill TERM # Send "TERM" signal
     kill -9   # same as above
     kill  9   # same as above
     kill! 9   # above, but no questions asked


### PR DESCRIPTION
Order of examples made the comments on those examples incorrect.
